### PR TITLE
Typo Correction, order of definitions, and changing from MASTER to MAIN

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,10 +177,11 @@ work in practice—that part will come later.
   _remote_ source and have a copy of that directory on our own system. We call
   the repo on our personal system the _local_ repo. (We'll talk more about the
   "clone" command later.)
-- **`master` branch**: You'll learn in advanced Git that a repo can support multiple
-  branches (we called those "sandboxes" earlier). For the moment, just remember this:
-  by default, when you create a Git repo, you will be working on the `master` branch.
-- **branch**: The combined history of all the changes of all the files in the repo.
+- **branch**: The combined history of all the changes of all the files in the repo. 
+  You'll learn in advanced Git that a repo can support multiple branches (those are 
+  the "sandboxes" we mentioned earlier).
+- **`master` branch**: For the moment, just remember this: by default, when you 
+  create a Git repo, you will be working on the `master` branch.
 
 ## Conclusion
 

--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ co-worker told us about and we can _try_ to replace our old code with this new i
 We can read about a new feature provided in a framework and _try_ it out in our
 old code. **VCS helps us be unafraid to try new and improved techniques**.
 
-> **ASIDE** The programmer, entrepreneur, and venture capitalist Paul Graham
+> **ASIDE**: The programmer, entrepreneur, and venture capitalist Paul Graham
 > notes that oil paints unlocked a revolution in experimentation in visual arts
 > because they were undo-able. Oils provided the **freedom** to err and recover
 > that other paint media did not provide (e.g. watercolor). Because of this

--- a/README.md
+++ b/README.md
@@ -180,8 +180,10 @@ work in practice—that part will come later.
 - **branch**: The combined history of all the changes of all the files in the repo. 
   You'll learn in advanced Git that a repo can support multiple branches (those are 
   the "sandboxes" we mentioned earlier).
-- **`master` branch**: For the moment, just remember this: by default, when you 
-  create a Git repo, you will be working on the `master` branch.
+- **`main` branch**: For the moment, just remember this: by default, when you 
+  create a Git repo, you will be working on the `main` branch. For many years, the
+  default branch for a Git repo was called `master`, so you may see this older
+  convention often on projects created before 2020. 
 
 ## Conclusion
 

--- a/README.md
+++ b/README.md
@@ -182,8 +182,8 @@ work in practice—that part will come later.
   the "sandboxes" we mentioned earlier).
 - **`main` branch**: For the moment, just remember this: by default, when you 
   create a Git repo, you will be working on the `main` branch. For many years, the
-  default branch for a Git repo was called `master`, so you may see this older
-  convention often on projects created before 2020. 
+  default branch for a Git repo was named `master`, so you will see this convention 
+  often on projects created before 2020. 
 
 ## Conclusion
 


### PR DESCRIPTION
1.  Typo corrected in ASIDE - there was a missing colon
2. Changed the order of the useful vocabulary terms to introduce the term "branch" before it's used in the term "main" or "master" branch
3. Changed reference of "master" to "main", since if the student has followed the steps previously of getting set up with Git on either Windows or Mac, the origin branch they will be creating for all their projects will be `main` instead of  `master`.